### PR TITLE
Use slices from exp repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Terrapin Vulnerability Scanner is a small utility program written in Go, whi
 
 For convenience, we are providing pre-compiled binaries for all major desktop platforms. These can be found on the [Release page](https://github.com/RUB-NDS/Terrapin-Scanner/releases/latest).
 
-However, we understand that you might prefer building tools, that connect to your SSH server, yourself. To do this, ensure that you have at least Go v1.21 installed. To compile and install the Terrapin Vulnerability Scanner Go package, run the command below.
+However, we understand that you might prefer building tools, that connect to your SSH server, yourself. To do this, ensure that you have at least Go v1.18 installed. To compile and install the Terrapin Vulnerability Scanner Go package, run the command below.
 
 ```
 go install github.com/RUB-NDS/Terrapin-Scanner@latest

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/RUB-NDS/Terrapin-Scanner
 
-go 1.21
+go 1.18
 
-require github.com/fatih/color v1.16.0
+require (
+	github.com/fatih/color v1.16.0
+	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
+)
 
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+golang.org/x/exp v0.0.0-20231219180239-dc181d75b848 h1:+iq7lrkxmFNBM7xx+Rae2W6uyPfhPeDWD+n+JgppptE=
+golang.org/x/exp v0.0.0-20231219180239-dc181d75b848/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=

--- a/tscanner/tscanner.go
+++ b/tscanner/tscanner.go
@@ -7,10 +7,10 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"io"
 	"net"
 	"os"
-	"slices"
 	"strings"
 )
 


### PR DESCRIPTION
The 'slices' module is not built in to older versions of go e.g. go1.18 on Ubuntu 22.04 LTS. Importing from golang.org/x/exp explicitly works on older and newer versions.

Tested with go1.18.1 and go1.21.5