### PR TITLE
Add a Dockerfile and GitHub Actions script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Convert image name to lowercase
         run: |
           GITHUB_REPOSITORY="${{ github.repository }}"
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
@@ -89,7 +89,7 @@ jobs:
       - name: Convert image name to lowercase
         run: |
           GITHUB_REPOSITORY="${{ github.repository }}"
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       - name: Download digests
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,6 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -69,13 +68,11 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
-        if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
-        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v3
         with:
           name: digests
@@ -85,7 +82,6 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - build
     steps:
@@ -106,7 +102,6 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,6 @@ jobs:
         uses: docker/build-push-action@v5.0.0
         with:
           context: .
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -67,11 +68,13 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v3
         with:
           name: digests
@@ -81,6 +84,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - build
     steps:
@@ -101,6 +105,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
       - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,7 @@ name: Build Docker Container
 
 on:
   push:
-    branches: ["main"]
-    # Publish semver tags as releases.
+    branches: ['**']
     tags: ["*.*.*"]
   pull_request:
     branches: ["main"]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,7 @@ jobs:
           GITHUB_REPOSITORY="${{ github.repository }}"
           echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: digests
           path: /tmp/digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -34,6 +33,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Convert image name to lowercase
+        run: |
+          GITHUB_REPOSITORY="${{ github.repository }}"
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.0.0
@@ -82,6 +86,10 @@ jobs:
     needs:
       - build
     steps:
+      - name: Convert image name to lowercase
+        run: |
+          GITHUB_REPOSITORY="${{ github.repository }}"
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       - name: Download digests
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,14 +66,16 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: ${{ matrix.platform }}
           provenance: true
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v3
         with:
           name: digests
@@ -83,6 +85,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
     needs:
       - build
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,34 +29,40 @@ jobs:
           - linux/s390x
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - 
+        name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Convert image name to lowercase
+      - 
+        name: Convert image name to lowercase
         run: |
           GITHUB_REPOSITORY="${{ github.repository }}"
           echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry ${{ env.REGISTRY }}
+      - 
+        name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract Docker metadata
+      - 
+        name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Build Docker image
+      - 
+        name: Build Docker image
         id: build
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
@@ -66,13 +72,15 @@ jobs:
           provenance: true
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
-      - name: Export digest
+      - 
+        name: Export digest
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
+      - 
+        name: Upload digest
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/upload-artifact@v3
         with:
@@ -87,34 +95,41 @@ jobs:
     needs:
       - build
     steps:
-      - name: Convert image name to lowercase
+      - 
+        name: Convert image name to lowercase
         run: |
           GITHUB_REPOSITORY="${{ github.repository }}"
           echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
-      - name: Download digests
+      - 
+        name: Download digests
         uses: actions/download-artifact@v3
         with:
           name: digests
           path: /tmp/digests
-      - name: Set up Docker Buildx
+      - 
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Docker meta
+      - 
+        name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-      - name: Log into registry ${{ env.REGISTRY }}
+      - 
+        name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create manifest list and push
+      - 
+        name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
-      - name: Inspect image
+      - 
+        name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,7 @@ jobs:
           GITHUB_REPOSITORY="${{ github.repository }}"
           echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: digests
           path: /tmp/digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,112 @@
+name: Build Docker Container
+
+on:
+  push:
+    branches: ["main"]
+    # Publish semver tags as releases.
+    tags: ["*.*.*"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+          - linux/386
+          - linux/ppc64le
+          - linux/s390x
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build Docker image
+        id: build
+        uses: docker/build-push-action@v5.0.0
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          provenance: true
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ COPY *.go ./
 COPY tscanner ./tscanner
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o Terrapin-Scanner
-
+RUN ["echo", "nobody:*:65534:65534:nobody:/_nonexistent:/bin/false", ">", "/etc/passwd"]
 FROM scratch
 
 COPY --from=builder /app/Terrapin-Scanner /app/Terrapin-Scanner
-
-USER nobody:nobody
+COPY --from=builder /etc/passwd /etc/passwd
+USER nobody
 
 ENTRYPOINT [ "/app/Terrapin-Scanner" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.18-alpine AS builder
 
 WORKDIR /app
 
@@ -10,5 +10,9 @@ COPY *.go ./
 COPY tscanner ./tscanner
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o Terrapin-Scanner
+
+FROM scratch
+
+COPY --from=builder /app/Terrapin-Scanner /app/Terrapin-Scanner
 
 ENTRYPOINT [ "/app/Terrapin-Scanner" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18-alpine
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY *.go ./
+COPY tscanner ./tscanner
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o Terrapin-Scanner
+
+ENTRYPOINT [ "/app/Terrapin-Scanner" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.18-alpine AS builder
+### Builder
+FROM golang:1.21-alpine AS builder
 
 WORKDIR /app
 
 COPY go.mod go.sum ./
-
 RUN go mod download
 
 COPY *.go ./
@@ -11,10 +11,13 @@ COPY tscanner ./tscanner
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o Terrapin-Scanner
 RUN ["echo", "nobody:*:65534:65534:nobody:/_nonexistent:/bin/false", ">", "/etc/passwd"]
+
+### Final image
 FROM scratch
 
 COPY --from=builder /app/Terrapin-Scanner /app/Terrapin-Scanner
 COPY --from=builder /etc/passwd /etc/passwd
+
 USER nobody
 
 LABEL org.opencontainers.image.description See https://github.com/RUB-NDS/Terrapin-Scanner?tab=readme-ov-file#usage for usage instructions. 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ FROM scratch
 
 COPY --from=builder /app/Terrapin-Scanner /app/Terrapin-Scanner
 
+USER nobody:nobody
+
 ENTRYPOINT [ "/app/Terrapin-Scanner" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,6 @@ COPY --from=builder /app/Terrapin-Scanner /app/Terrapin-Scanner
 COPY --from=builder /etc/passwd /etc/passwd
 USER nobody
 
+LABEL org.opencontainers.image.description See https://github.com/RUB-NDS/Terrapin-Scanner?tab=readme-ov-file#usage for usage instructions. 
+
 ENTRYPOINT [ "/app/Terrapin-Scanner" ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ The Terrapin Vulnerability Scanner is a small utility program written in Go, whi
 
 ## Building
 
-For convenience, we are providing pre-compiled binaries for all major desktop platforms. These can be found on the [Release page](https://github.com/RUB-NDS/Terrapin-Scanner/releases/latest).
+For convenience, we are providing pre-compiled binaries for all major desktop platforms. These can be found on the [Release page](https://github.com/RUB-NDS/Terrapin-Scanner/releases/latest). We have also provided a Docker image that supports most of the major architectures. This image can be run as:
+
+```bash
+docker run -it ghcr.io/rub-nds/terrapin-scanner <args>
+```
 
 However, we understand that you might prefer building tools, that connect to your SSH server, yourself. To do this, ensure that you have at least Go v1.18 installed. To compile and install the Terrapin Vulnerability Scanner Go package, run the command below.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also build the Docker image yourself by running the commands below.
 
 ```bash
 git clone https://github.com/RUB-NDS/Terrapin-Scanner.git
-docker build -t terrapin-scanner .
+docker build -t terrapin-scanner Terrapin-Scanner
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ docker run -it ghcr.io/rub-nds/terrapin-scanner <args>
 
 However, we understand that you might prefer building tools, that connect to your SSH server, yourself. To do this, ensure that you have at least Go v1.18 installed. To compile and install the Terrapin Vulnerability Scanner Go package, run the command below.
 
-```
+```bash
 go install github.com/RUB-NDS/Terrapin-Scanner@latest
 ```
 
 This will download, compile, and install the Go package for your local system. The compiled binary will become available at `$GOBIN/Terrapin-Scanner`. If the `GOBIN` environment variable is not set, Go will default to using `$GOPATH/bin` or `$HOME/go/bin`, depending on whether the `$GOPATH` environment variable is set.
+
+You can also build the Docker image yourself by running the commands below.
+
+```bash
+git clone https://github.com/RUB-NDS/Terrapin-Scanner.git
+docker build -t terrapin-scanner .
+```
 
 ## Usage
 


### PR DESCRIPTION
This allows someone to manually build the Docker image or just use the prebuilt one (built with GitHub Actions).

Fix #18 

Note: In order for the Docker image to be pullable, another release will have to be made so a new tag is created.